### PR TITLE
nvptx: loop: Allow loops to not start from 0

### DIFF
--- a/DevRTLs/nvptx/src/loop.cu
+++ b/DevRTLs/nvptx/src/loop.cu
@@ -109,8 +109,7 @@ INLINE static void for_static_init(int32_t schedtype,
 	  GetOmpThreadId(gtid), schedtype, P64(chunk));
 
   // copy
-  ASSERT0(LT_FUSSY, *plower==0, "exected normalized loop");
-  T lb = 0;
+  T lb = *plower;
   T ub = *pupper;
   ST stride = *pstride;
   T entityId, numberOfEntities;


### PR DESCRIPTION
This will happen when using teams constructs.

``` C
#include <stdlib.h>
#include <stdio.h>

int main(int argc, char* argv[])
{
    const int n = 1024;
    int i, count = 0;

    #pragma omp target
    #pragma omp teams num_teams(2)
    #pragma omp distribute parallel for reduction(+:count)
    for (i = 0; i < n; i++) {
        count++;
    }

    printf("count=%d, expected %d\n", count, n);

    return EXIT_SUCCESS;
}
```

Current master: `count=1536, expected 1024`
With this change: `count=1024, expected 1024`

Additionally the assertion would trigger if build for debug...
