### PR TITLE
CMake: add support for multiple GPU architectures

### DIFF
--- a/DevRTLs/nvptx/CMakeLists.txt
+++ b/DevRTLs/nvptx/CMakeLists.txt
@@ -33,8 +33,11 @@ if(CUDA_FOUND)
 
     message("Building NVPTX device RTL")
 
-    if(DEFINED ${OMPTARGET_NVPTX_SM})
-        set(CUDA_ARCH -arch sm_${OMPTARGET_NVPTX_SM})
+    if(DEFINED OMPTARGET_NVPTX_SM)
+        string(REPLACE "," ";" omptarget_nvptx_sm_list ${OMPTARGET_NVPTX_SM})
+        foreach(sm ${omptarget_nvptx_sm_list})
+           set(CUDA_ARCH ${CUDA_ARCH} -gencode arch=compute_${sm},code=sm_${sm})
+        endforeach()
     else()
         set(CUDA_ARCH -arch sm_35)
     endif()

--- a/README.md
+++ b/README.md
@@ -79,9 +79,12 @@ execution.
 
 The current implementation includes a library for:
   - nvptx: library written in CUDA for Nvidia GPUs. Tested with CUDA compilation 
-  tools V7.0.27. In order to use this library with Clang the user has to set 
-  LIBRARY_PATH to point to ./lib so that Clang passes the right information to 
-  the target linker.
+  tools V7.0.27. The CUDA architecture can be set using cmake by setting 
+  OMPTARGET\_NVPTX\_SM to a comma seperated list of target architectures. For 
+  example, to compile for sm\_30 and sm\_35 one can define 
+  `-DOMPTARGET_NVPTX_SM=30,35` when calling cmake. In order to use this library 
+  with Clang the user has to set LIBRARY_PATH to point to ./lib so that Clang 
+  passes the right information to the target linker.
        
 For powerpc64, powerpc64le and x86_64 devices, existing host runtime libraries 
 (e.g. openmp.llvm.org) can be used for when these devices are used as OpenMP 


### PR DESCRIPTION
With this commit it is possible to specify multiple GPU architectures (e.g. sm_30, sm_35) for the nvptx DevRTL when invoking cmake. It is a small modification of a cmake file, and a little documentation. 

It also fixes the issue #4 I submitted yesterday.
