### PR TITLE
CUDA: Fix output of error string

### DIFF
--- a/RTLs/cuda/src/rtl.cpp
+++ b/RTLs/cuda/src/rtl.cpp
@@ -33,18 +33,13 @@
 #define DP(...) DEBUGP("Target " GETNAME(TARGET_NAME) " RTL",__VA_ARGS__)
 
 // Utility for retrieving and printing CUDA error string
-// FIXME: Unfortunately, the error string feature does not work on some machines
-// so it is deactivated for the moment.
 #ifdef CUDA_ERROR_REPORT
-#define CUDA_ERR_STRING(err)        \
-    DP("CUDA error is: %d (see cuda.h)\n", err)
-
-//#define CUDA_ERR_STRING(err) {        \
-//    DP("CUDA error is: %s\n", *errStr);     \
-//    const char ** errStr;       \
-//    cuGetErrorString (err, errStr);     \
-//    DP("CUDA error is: %s\n", *errStr);     \
-//}
+#define CUDA_ERR_STRING(err)               \
+    do {                                   \
+        const char* errStr;                \
+        cuGetErrorString (err, &errStr);   \
+        DP("CUDA error is: %s\n", errStr); \
+    } while (0)
 #else
 #define CUDA_ERR_STRING(err) {}
 #endif


### PR DESCRIPTION
The pointer passed to cuGeterrorString must be initialized and we want to have the result in errStr.

This works at least on my test system (got segmentation faults before)
