### PR TITLE
Add identifiers to offloaded variables

### DIFF
--- a/RTLs/cuda/src/rtl.cpp
+++ b/RTLs/cuda/src/rtl.cpp
@@ -430,7 +430,7 @@ __tgt_target_table *__tgt_rtl_load_binary(int32_t device_id, __tgt_device_image 
   return DeviceInfo.getOffloadEntriesTable(device_id);
 }
 
-void *__tgt_rtl_data_alloc(int32_t device_id, int64_t size){
+void *__tgt_rtl_data_alloc(int32_t device_id, int64_t size, int32_t id){
 
   //Set the context we are using  
   CUresult err = cuCtxSetCurrent (DeviceInfo.Contexts[device_id]);
@@ -454,7 +454,7 @@ void *__tgt_rtl_data_alloc(int32_t device_id, int64_t size){
   return vptr;
 }
 
-int32_t __tgt_rtl_data_submit(int32_t device_id, void *tgt_ptr, void *hst_ptr, int64_t size){
+int32_t __tgt_rtl_data_submit(int32_t device_id, void *tgt_ptr, void *hst_ptr, int64_t size, int32_t id){
   //Set the context we are using
   CUresult err = cuCtxSetCurrent (DeviceInfo.Contexts[device_id]);
   if (err != CUDA_SUCCESS)
@@ -476,7 +476,7 @@ int32_t __tgt_rtl_data_submit(int32_t device_id, void *tgt_ptr, void *hst_ptr, i
   return OFFLOAD_SUCCESS;
 }
 
-int32_t __tgt_rtl_data_retrieve(int32_t device_id, void *hst_ptr, void *tgt_ptr, int64_t size){
+int32_t __tgt_rtl_data_retrieve(int32_t device_id, void *hst_ptr, void *tgt_ptr, int64_t size, int32_t id){
   //Set the context we are using
   CUresult err = cuCtxSetCurrent (DeviceInfo.Contexts[device_id]);
   if (err != CUDA_SUCCESS)
@@ -498,7 +498,7 @@ int32_t __tgt_rtl_data_retrieve(int32_t device_id, void *hst_ptr, void *tgt_ptr,
   return OFFLOAD_SUCCESS;
 }
 
-int32_t __tgt_rtl_data_delete(int32_t device_id, void* tgt_ptr){
+int32_t __tgt_rtl_data_delete(int32_t device_id, void* tgt_ptr, int32_t id){
   //Set the context we are using
   CUresult err = cuCtxSetCurrent (DeviceInfo.Contexts[device_id]);
   if (err != CUDA_SUCCESS)

--- a/RTLs/generic-64bit/src/rtl.cpp
+++ b/RTLs/generic-64bit/src/rtl.cpp
@@ -252,22 +252,22 @@ __tgt_target_table *__tgt_rtl_load_binary(int32_t device_id, __tgt_device_image 
   return DeviceInfo.getOffloadEntriesTable(device_id);
 }
 
-void *__tgt_rtl_data_alloc(int32_t device_id, int64_t size){
+void *__tgt_rtl_data_alloc(int32_t device_id, int64_t size, int32_t id){
   void *ptr = malloc(size);
   return ptr;
 }
 
-int32_t __tgt_rtl_data_submit(int32_t device_id, void *tgt_ptr, void *hst_ptr, int64_t size){
+int32_t __tgt_rtl_data_submit(int32_t device_id, void *tgt_ptr, void *hst_ptr, int64_t size, int32_t id){
   memcpy(tgt_ptr,hst_ptr,size);
   return OFFLOAD_SUCCESS;
 }
 
-int32_t __tgt_rtl_data_retrieve(int32_t device_id, void *hst_ptr, void *tgt_ptr, int64_t size){
+int32_t __tgt_rtl_data_retrieve(int32_t device_id, void *hst_ptr, void *tgt_ptr, int64_t size, int32_t id){
   memcpy(hst_ptr,tgt_ptr,size);
   return OFFLOAD_SUCCESS;
 }
 
-int32_t __tgt_rtl_data_delete(int32_t device_id, void* tgt_ptr){
+int32_t __tgt_rtl_data_delete(int32_t device_id, void* tgt_ptr, int32_t id){
   free(tgt_ptr);
   return OFFLOAD_SUCCESS;
 }


### PR DESCRIPTION
Hi all,

Some of my colleagues and I are currently developing the infrastructure for adding a new device, the cloud, to the list of available targets. Considering the cloud as a device requires few changes to the API of the offloading library (libomptarget). Indeed, our cloud device handles offloading data thanks to files instead of values within an address space. To do so, we had to associate each offloaded variables with a unique identifier.

As suggested by @sfantao on [OpenMP mailing-list](http://lists.llvm.org/pipermail/openmp-dev/2015-October/000955.html), I submit my patch as a pull request. This part updates libomptarget behavior  (see clang-omp/clang_trunk#27 for the other part):
The offloading function `__tgt_target` is now called with an additional argument: a unique identifier (as int) attributed to each offloaded variable by Clang. This identifier is then transmitted to the RTL device when calling functions of alloc/submit/etc.
In case of pointer addresses (not the value of the variable), the special identifier "-1" is attributed. This allows us to easily skip the offloading of these addresses that our device doesn't use.

Let's us precise that we plan to open source all this work and to submit patches to the upstream Clang/OpenMP repositories when it will be mature enough. Additionally to simplify future integrations, those API changes can be helpful for any exotic offloading target. That's why we propose to integrate them directly.

Regards,
Hervé
